### PR TITLE
Feat/18 show createing

### DIFF
--- a/src/contexts/TextEditorProvider.tsx
+++ b/src/contexts/TextEditorProvider.tsx
@@ -88,6 +88,7 @@ export const TextEditorProvider: React.FC = ({ children }) => {
         <TextField
           autoFocus
           value={value}
+          placeholder="Input Text"
           onChange={handleChange}
           onKeyDown={handleKeyDown}
           onBlur={handleBlur}

--- a/src/features/canvas/components/Canvas.tsx
+++ b/src/features/canvas/components/Canvas.tsx
@@ -132,9 +132,14 @@ export const Canvas = () => {
   const handleMouseDown = (event: Konva.KonvaEventObject<MouseEvent>) => {
     const pos = event.target.getStage()?.getPointerPosition()
     if (pos) {
-      setStart(pos)
+      if (shapeType === 'Text') {
+        const { clientX, clientY } = event.evt
+        pos.x = clientX
+        pos.y = clientY
+      }
       const shape = CreateShape(shapeType, pos, pos)
       setNewShape(shape)
+      setStart(pos)
     }
   }
   const handleMouseMove = (event: Konva.KonvaEventObject<MouseEvent>) => {
@@ -149,9 +154,8 @@ export const Canvas = () => {
 
     if (pos) {
       if (shapeType === 'Text') {
-        const { clientX, clientY } = event.evt
         edit({
-          pos: { x: clientX, y: clientY },
+          pos: start,
           value: '',
         }).then((result) => {
           if (result) {

--- a/src/features/canvas/components/Canvas.tsx
+++ b/src/features/canvas/components/Canvas.tsx
@@ -110,6 +110,7 @@ const PasteObject = async (data: string | File) => {
 
 export const Canvas = () => {
   const { shapeType } = React.useContext(ShapeTypeContext)
+  const [newShape, setNewShape] = React.useState<React.ReactNode>()
   const [start, setStart] = React.useState<Vector2d>({
     x: 0,
     y: 0,
@@ -132,6 +133,15 @@ export const Canvas = () => {
     const pos = event.target.getStage()?.getPointerPosition()
     if (pos) {
       setStart(pos)
+      const shape = CreateShape(shapeType, pos, pos)
+      setNewShape(shape)
+    }
+  }
+  const handleMouseMove = (event: Konva.KonvaEventObject<MouseEvent>) => {
+    const pos = event.target.getStage()?.getPointerPosition()
+    if (pos && newShape) {
+      const shape = CreateShape(shapeType, start, pos)
+      setNewShape(shape)
     }
   }
   const handleMouseUp = (event: Konva.KonvaEventObject<MouseEvent>) => {
@@ -150,12 +160,11 @@ export const Canvas = () => {
           }
         })
       }
-      const shape = CreateShape(shapeType, start, pos)
-      if (shape) {
-        console.log(shape)
-        setKonvaItems((prev) => [...prev, shape])
+      if (newShape) {
+        setKonvaItems((prev) => [...prev, newShape])
       }
     }
+    setNewShape(undefined)
     setStart({ x: 0, y: 0 })
   }
   return (
@@ -165,11 +174,13 @@ export const Canvas = () => {
           width={1000}
           height={1000}
           onMouseDown={handleMouseDown}
+          onMouseMove={handleMouseMove}
           onMouseUp={handleMouseUp}>
           <TextEditorContext.Provider value={value}>
             <Layer>
               <TextBlock point={{ x: 200, y: 200 }} />
               {React.Children.toArray(konvaItems).map((item) => item)}
+              {newShape}
             </Layer>
           </TextEditorContext.Provider>
         </Stage>

--- a/src/features/canvas/components/TextBlock.tsx
+++ b/src/features/canvas/components/TextBlock.tsx
@@ -24,7 +24,6 @@ const TextBlock = ({ point, defaultValue = 'default' }: Props) => {
     edit({ pos, value })
       .then((result) => {
         setValue(result)
-        console.log('then: ' + result)
       })
       .catch((result) => console.log(result))
       .finally(() => text.show())


### PR DESCRIPTION
close #18 

- onMouseMove イベントを追加して、描画予定のオブジェクトを表示するようにした
    - onMouseDown 時に newShape オブジェクトを作成
    - newShape は常にキャンバス上に描画
    - newShape が有効であれば MouseMove 中に newShape を更新
    - MouseUp 時に newShape を items に追加
    - ついでに newShape を undefined に更新
- Text の場合は描画しない
    - ついでに Text の描画位置をクリックした場所に変更