### PR TITLE
Feat/7 save image

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,18 @@
 import * as React from 'react'
 
 import { PasteDataProvider } from 'contexts/PasteDataProvider'
+import { StageRefProvider } from 'contexts/StageRefProvider'
 import { TextEditorProvider } from 'contexts/TextEditorProvider'
 import Root from 'pages/Root'
 
 function App() {
   return (
     <PasteDataProvider>
-      <TextEditorProvider>
-        <Root />
-      </TextEditorProvider>
+      <StageRefProvider>
+        <TextEditorProvider>
+          <Root />
+        </TextEditorProvider>
+      </StageRefProvider>
     </PasteDataProvider>
   )
 }

--- a/src/contexts/StageRefProvider.tsx
+++ b/src/contexts/StageRefProvider.tsx
@@ -1,0 +1,11 @@
+import Konva from 'konva'
+import * as React from 'react'
+
+type StageRefProps = React.RefObject<Konva.Stage> | undefined
+export const StageRef = React.createContext<StageRefProps>(undefined)
+
+export const StageRefProvider: React.FC = ({ children }) => {
+  const stageRef = React.useRef<Konva.Stage>(null)
+
+  return <StageRef.Provider value={stageRef}>{children}</StageRef.Provider>
+}

--- a/src/features/canvas/components/Canvas.tsx
+++ b/src/features/canvas/components/Canvas.tsx
@@ -16,7 +16,12 @@ import TextBlock from './TextBlock'
 import { TextEditorContext } from 'contexts/TextEditorProvider'
 import { StageRef } from 'contexts/StageRefProvider'
 
-const CreateShape = (shape: string, p1: Vector2d, p2: Vector2d) => {
+const CreateShape = (
+  shape: string,
+  p1: Vector2d,
+  p2: Vector2d,
+  config: Konva.ShapeConfig = {}
+) => {
   switch (shape) {
     case 'Circle': {
       const center = {
@@ -35,6 +40,7 @@ const CreateShape = (shape: string, p1: Vector2d, p2: Vector2d) => {
           radiusY={radius.y}
           fill="gray"
           stroke="blue"
+          {...config}
         />
       )
     }
@@ -55,12 +61,18 @@ const CreateShape = (shape: string, p1: Vector2d, p2: Vector2d) => {
           height={widthHeight.y}
           fill="gray"
           stroke="blue"
+          {...config}
         />
       )
     }
     case 'Line':
       return (
-        <Line points={[p1.x, p1.y, p2.x, p2.y]} stroke="blue" strokeWidth={4} />
+        <Line
+          points={[p1.x, p1.y, p2.x, p2.y]}
+          stroke="blue"
+          strokeWidth={4}
+          {...config}
+        />
       )
     default:
       break
@@ -203,7 +215,10 @@ export const Canvas = () => {
         x: stageRef.current.width(),
         y: stageRef.current.height(),
       }
-      const rect = CreateShape('Rect', { x: 0, y: 0 }, stageEnd)
+      const rect = CreateShape('Rect', { x: 0, y: 0 }, stageEnd, {
+        fill: 'white',
+        stroke: 'transparent',
+      })
       setBackground(rect)
     }
   }, [stageRef])

--- a/src/features/canvas/components/Canvas.tsx
+++ b/src/features/canvas/components/Canvas.tsx
@@ -194,7 +194,20 @@ export const Canvas = () => {
     setNewShape(line)
   }, [freePoints])
 
+  const [background, setBackground] = React.useState<React.ReactNode>()
+
   const stageRef = React.useContext(StageRef)
+  React.useEffect(() => {
+    if (stageRef?.current) {
+      const stageEnd = {
+        x: stageRef.current.width(),
+        y: stageRef.current.height(),
+      }
+      const rect = CreateShape('Rect', { x: 0, y: 0 }, stageEnd)
+      setBackground(rect)
+    }
+  }, [stageRef])
+
   return (
     <TextEditorContext.Consumer>
       {(value) => (
@@ -207,6 +220,7 @@ export const Canvas = () => {
           onMouseUp={handleMouseUp}>
           <TextEditorContext.Provider value={value}>
             <Layer>
+              {background}
               <TextBlock point={{ x: 200, y: 200 }} />
               {React.Children.toArray(konvaItems).map((item) => item)}
               {newShape}

--- a/src/features/canvas/components/Canvas.tsx
+++ b/src/features/canvas/components/Canvas.tsx
@@ -14,6 +14,7 @@ import { PasteData } from 'contexts/PasteDataProvider'
 import { Vector2d } from 'konva/lib/types'
 import TextBlock from './TextBlock'
 import { TextEditorContext } from 'contexts/TextEditorProvider'
+import { StageRef } from 'contexts/StageRefProvider'
 
 const CreateShape = (shape: string, p1: Vector2d, p2: Vector2d) => {
   switch (shape) {
@@ -192,10 +193,13 @@ export const Canvas = () => {
     const line = drawFreeLine(freePoints)
     setNewShape(line)
   }, [freePoints])
+
+  const stageRef = React.useContext(StageRef)
   return (
     <TextEditorContext.Consumer>
       {(value) => (
         <Stage
+          ref={stageRef}
           width={1000}
           height={1000}
           onMouseDown={handleMouseDown}

--- a/src/features/canvas/components/Navbar.tsx
+++ b/src/features/canvas/components/Navbar.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react'
+import { styled } from '@mui/material'
 import AppBar from '@mui/material/AppBar'
+import Button from '@mui/material/Button'
 import FormControl from '@mui/material/FormControl'
 import InputLabel from '@mui/material/InputLabel'
 import MenuItem from '@mui/material/MenuItem'
@@ -7,17 +9,34 @@ import Select, { SelectChangeEvent } from '@mui/material/Select'
 import Toolbar from '@mui/material/Toolbar'
 
 import { ShapeTypeContext } from 'pages/Root'
+import { StageRef } from 'contexts/StageRefProvider'
+
+const FlexDiv = styled('div')((theme) => ({
+  flexGrow: 1,
+}))
 
 const Navbar = () => {
   const { shapeType, setShapeType } = React.useContext(ShapeTypeContext)
   const handleChange = (event: SelectChangeEvent) => {
     setShapeType(event.target.value)
   }
+  const stageRef = React.useContext(StageRef)
+  const handleDownload = () => {
+    if (stageRef?.current) {
+      const dataUrl = stageRef.current.toDataURL()
+      const link = document.createElement('a')
+      link.download = 'stage.png'
+      link.href = dataUrl
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+    }
+  }
 
   return (
     <AppBar>
       <Toolbar>
-        <FormControl fullWidth>
+        <FormControl>
           <InputLabel id="shape-select-label">Shape</InputLabel>
           <Select
             labelId="shape-select-label"
@@ -33,6 +52,10 @@ const Navbar = () => {
             <MenuItem value={'Text'}>Text</MenuItem>
           </Select>
         </FormControl>
+        <FlexDiv />
+        <Button onClick={handleDownload} variant="contained">
+          Download
+        </Button>
       </Toolbar>
     </AppBar>
   )


### PR DESCRIPTION
close #7 

- Nav bar 右上にダウンロードボタンを追加
- クリックするとCanvas を PNG に変換した画像を保存できる
- キャンバスの背景代わりにキャンバスサイズと同じ大きさの四角形を描画
  - Konva 公式ドキュメントのやり方なので、他に方法はないと思われる
  - <https://konvajs.org/docs/sandbox/Canvas_Background.html#page-title>
- CreateShape メソッドに ShapeConfig オプションを追加
  - 一般的なオプションはこれで対応可能
  - 図形固有のオプションについては別途検討