### PR TITLE
Feat/10 move object

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,30 @@
 import * as React from 'react'
+import { createTheme, ThemeProvider } from '@mui/material/styles'
 
 import { PasteDataProvider } from 'contexts/PasteDataProvider'
 import { StageRefProvider } from 'contexts/StageRefProvider'
 import { TextEditorProvider } from 'contexts/TextEditorProvider'
 import Root from 'pages/Root'
 
+const customTheme = createTheme({
+  palette: {
+    primary: {
+      main: '#20b2aa',
+    },
+  },
+})
+
 function App() {
   return (
-    <PasteDataProvider>
-      <StageRefProvider>
-        <TextEditorProvider>
-          <Root />
-        </TextEditorProvider>
-      </StageRefProvider>
-    </PasteDataProvider>
+    <ThemeProvider theme={customTheme}>
+      <PasteDataProvider>
+        <StageRefProvider>
+          <TextEditorProvider>
+            <Root />
+          </TextEditorProvider>
+        </StageRefProvider>
+      </PasteDataProvider>
+    </ThemeProvider>
   )
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,13 +6,7 @@ import { StageRefProvider } from 'contexts/StageRefProvider'
 import { TextEditorProvider } from 'contexts/TextEditorProvider'
 import Root from 'pages/Root'
 
-const customTheme = createTheme({
-  palette: {
-    primary: {
-      main: '#20b2aa',
-    },
-  },
-})
+const customTheme = createTheme()
 
 function App() {
   return (

--- a/src/contexts/TextEditorProvider.tsx
+++ b/src/contexts/TextEditorProvider.tsx
@@ -4,30 +4,23 @@ import InputUnstyled from '@mui/base/InputUnstyled'
 import { styled } from '@mui/system'
 import { Vector2d } from 'konva/lib/types'
 
-const StyledInputElement = styled('input')(
-  ({ theme }) => `
-  width: 320px;
-  font-size: 0.875rem;
-  font-family: IBM Plex Sans, sans-serif;
-  font-weight: 400;
-  line-height: 1.5;
-  color: grey.900;
-  background: transparent;
-  border-radius: 0px;
-  padding: 12px 12px;
-  transition: all 150ms ease;
-  font-size: 20;
-  padding: 0;
-  border: 'none';
-  border: 1px solid ${theme.palette.grey[900]};
+const StyledInputElement = styled('input')(({ theme }) => ({
+  width: '320px',
+  fontSize: 20,
+  fontWeight: 400,
+  lineHeight: 0,
+  background: 'transparent',
+  borderRadius: '0px',
+  padding: '0px',
+  transition: 'all 150ms ease',
+  border: 'none',
 
-  &:focus {
-    outline: none;
-    border: 1px solid ${theme.palette.grey[900]};
-    border-radius: 0px;
-  }
-`
-)
+  '&:focus': {
+    outline: 'none',
+    border: `1px solid ${theme.palette.grey[900]}`,
+    borderRadius: '0px',
+  },
+}))
 
 type EditorOptions = {
   pos: Vector2d
@@ -118,8 +111,8 @@ export const TextEditorProvider: React.FC = ({ children }) => {
         <div
           style={{
             position: 'absolute',
-            left: options.pos.x,
-            top: options.pos.y,
+            left: options.pos.x - 1,
+            top: options.pos.y - 3,
           }}>
           <InputUnstyled
             autoFocus

--- a/src/contexts/TextEditorProvider.tsx
+++ b/src/contexts/TextEditorProvider.tsx
@@ -1,6 +1,33 @@
 import * as React from 'react'
-import TextField from '@mui/material/TextField'
+// import TextField from '@mui/material/TextField'
+import InputUnstyled from '@mui/base/InputUnstyled'
+import { styled } from '@mui/system'
 import { Vector2d } from 'konva/lib/types'
+
+const StyledInputElement = styled('input')(
+  ({ theme }) => `
+  width: 320px;
+  font-size: 0.875rem;
+  font-family: IBM Plex Sans, sans-serif;
+  font-weight: 400;
+  line-height: 1.5;
+  color: grey.900;
+  background: transparent;
+  border-radius: 0px;
+  padding: 12px 12px;
+  transition: all 150ms ease;
+  font-size: 20;
+  padding: 0;
+  border: 'none';
+  border: 1px solid ${theme.palette.grey[900]};
+
+  &:focus {
+    outline: none;
+    border: 1px solid ${theme.palette.grey[900]};
+    border-radius: 0px;
+  }
+`
+)
 
 type EditorOptions = {
   pos: Vector2d
@@ -53,7 +80,10 @@ export const TextEditorProvider: React.FC = ({ children }) => {
     }
   }, [reject, handleClose, value])
 
+  console.log(options)
+  const inputRef = React.useRef<HTMLInputElement>()
   const handleComplete = React.useCallback(() => {
+    console.log(inputRef.current?.getBoundingClientRect())
     if (resolve) {
       resolve(value)
       handleClose()
@@ -76,7 +106,7 @@ export const TextEditorProvider: React.FC = ({ children }) => {
 
   const handleBlur = () => {
     // When focus is out
-    handleComplete()
+    // handleComplete()
   }
 
   return (
@@ -85,16 +115,24 @@ export const TextEditorProvider: React.FC = ({ children }) => {
         {children}
       </TextEditorContext.Provider>
       {resolveReject.length > 0 && (
-        <TextField
-          autoFocus
-          value={value}
-          placeholder="Input Text"
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
-          onBlur={handleBlur}
-          inputProps={{ sx: { padding: 0 } }}
-          sx={{ position: 'absolute', left: options.pos.x, top: options.pos.y }}
-        />
+        <div
+          style={{
+            position: 'absolute',
+            left: options.pos.x,
+            top: options.pos.y,
+          }}>
+          <InputUnstyled
+            autoFocus
+            value={value}
+            placeholder="Input Text"
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            onBlur={handleBlur}
+            components={{
+              Input: StyledInputElement,
+            }}
+          />
+        </div>
       )}
     </>
   )

--- a/src/contexts/TextEditorProvider.tsx
+++ b/src/contexts/TextEditorProvider.tsx
@@ -92,6 +92,7 @@ export const TextEditorProvider: React.FC = ({ children }) => {
           onChange={handleChange}
           onKeyDown={handleKeyDown}
           onBlur={handleBlur}
+          inputProps={{ sx: { padding: 0 } }}
           sx={{ position: 'absolute', left: options.pos.x, top: options.pos.y }}
         />
       )}

--- a/src/features/canvas/components/Canvas.tsx
+++ b/src/features/canvas/components/Canvas.tsx
@@ -81,9 +81,20 @@ const CreateShape = (
   }
 }
 
-const drawFreeLine = (points: number[]) => {
+const drawFreeLine = (
+  points: number[],
+  config: Konva.ShapeConfig = {
+    draggable: true,
+  }
+) => {
   return (
-    <Line points={points} mode="source-over" stroke="blue" strokeWidth={4} />
+    <Line
+      points={points}
+      mode="source-over"
+      stroke="blue"
+      strokeWidth={4}
+      {...config}
+    />
   )
 }
 

--- a/src/features/canvas/components/Canvas.tsx
+++ b/src/features/canvas/components/Canvas.tsx
@@ -20,7 +20,9 @@ const CreateShape = (
   shape: string,
   p1: Vector2d,
   p2: Vector2d,
-  config: Konva.ShapeConfig = {}
+  config: Konva.ShapeConfig = {
+    draggable: true,
+  }
 ) => {
   switch (shape) {
     case 'Circle': {
@@ -231,6 +233,8 @@ export const Canvas = () => {
           width={1000}
           height={1000}
           onMouseDown={handleMouseDown}
+          // Prevent to create a small shape on dragging is started when set Shape type is not "select"
+          onDragStart={() => newShape && setNewShape(undefined)}
           onMouseMove={handleMouseMove}
           onMouseUp={handleMouseUp}>
           <TextEditorContext.Provider value={value}>

--- a/src/features/canvas/components/Canvas.tsx
+++ b/src/features/canvas/components/Canvas.tsx
@@ -140,6 +140,8 @@ export const Canvas = () => {
   const [freePoints, setFreePoints] = React.useState<number[]>([])
   const pasteData = React.useContext(PasteData)
   const edit = React.useContext(TextEditorContext)
+  const [absPos, setAbsPos] = React.useState<Vector2d>()
+  const stageRef = React.useContext(StageRef)
 
   React.useEffect(() => {
     if (pasteData !== undefined) {
@@ -156,8 +158,10 @@ export const Canvas = () => {
     if (pos) {
       if (shapeType === 'Text') {
         const { clientX, clientY } = event.evt
-        pos.x = clientX
-        pos.y = clientY
+        setAbsPos({
+          x: clientX,
+          y: clientY,
+        })
       } else if (shapeType === 'Free') {
         setFreePoints((prev) => [pos.x, pos.y, pos.x, pos.y])
         return
@@ -181,23 +185,21 @@ export const Canvas = () => {
     }
   }
   const handleMouseUp = (event: Konva.KonvaEventObject<MouseEvent>) => {
-    const pos = event.target.getStage()?.getPointerPosition()
-
-    if (pos) {
-      if (shapeType === 'Text') {
+    if (shapeType === 'Text') {
+      if (absPos && stageRef?.current) {
         edit({
-          pos: start,
+          pos: absPos,
           value: '',
         }).then((result) => {
           if (result) {
-            const shape = <TextBlock point={pos} defaultValue={result} />
+            const shape = <TextBlock point={start} value={result} />
             setKonvaItems((prev) => [...prev, shape])
           }
         })
       }
-      if (newShape) {
-        setKonvaItems((prev) => [...prev, newShape])
-      }
+    }
+    if (newShape) {
+      setKonvaItems((prev) => [...prev, newShape])
     }
     setNewShape(undefined)
     setStart({ x: 0, y: 0 })
@@ -210,7 +212,6 @@ export const Canvas = () => {
 
   const [background, setBackground] = React.useState<React.ReactNode>()
 
-  const stageRef = React.useContext(StageRef)
   React.useEffect(() => {
     if (stageRef?.current) {
       const stageEnd = {

--- a/src/features/canvas/components/TextBlock.tsx
+++ b/src/features/canvas/components/TextBlock.tsx
@@ -7,9 +7,9 @@ import { TextEditorContext } from 'contexts/TextEditorProvider'
 
 type Props = {
   point: Konva.Vector2d
-  defaultValue?: string
+  value?: string
 }
-const TextBlock = ({ point, defaultValue = 'default' }: Props) => {
+const TextBlock = ({ point, value: defaultValue = 'default' }: Props) => {
   const [value, setValue] = React.useState(defaultValue)
   const edit = React.useContext(TextEditorContext)
 
@@ -34,6 +34,7 @@ const TextBlock = ({ point, defaultValue = 'default' }: Props) => {
       text={value}
       fontSize={20}
       {...point}
+      draggable
       onDblClick={handleDoubleClick}
       onClick={(e) => e.evt.preventDefault()}
     />

--- a/src/features/canvas/components/TextBlock.tsx
+++ b/src/features/canvas/components/TextBlock.tsx
@@ -4,6 +4,7 @@ import Konva from 'konva'
 import { KonvaEventObject } from 'konva/lib/Node'
 
 import { TextEditorContext } from 'contexts/TextEditorProvider'
+import { useTheme } from '@mui/material/styles'
 
 type Props = {
   point: Konva.Vector2d
@@ -12,6 +13,7 @@ type Props = {
 const TextBlock = ({ point, value: defaultValue = 'default' }: Props) => {
   const [value, setValue] = React.useState(defaultValue)
   const edit = React.useContext(TextEditorContext)
+  const theme = useTheme()
 
   const handleDoubleClick = (event: KonvaEventObject<MouseEvent>) => {
     const text = event.target
@@ -32,6 +34,7 @@ const TextBlock = ({ point, value: defaultValue = 'default' }: Props) => {
   return (
     <Text
       text={value}
+      fontFamily={theme.typography.fontFamily}
       fontSize={20}
       {...point}
       draggable


### PR DESCRIPTION
Close #10 

- 各オブジェクトを移動可能にした
    - Select Mode のときにドラッグで移動可能
- Text 編集時のエディターモードをシンプルに
    - 編集場所と表示場所が一致するようするため
    - `UnstyledInput` を使用し一からスタイリング