### PR TITLE
Feat/33 mobile support

### DIFF
--- a/src/features/canvas/components/Canvas.tsx
+++ b/src/features/canvas/components/Canvas.tsx
@@ -199,7 +199,29 @@ export const Canvas = () => {
       setStart(pos)
     }
   }
-  const handleMouseMove = (event: Konva.KonvaEventObject<MouseEvent>) => {
+  const handleTouchStart = (event: Konva.KonvaEventObject<TouchEvent>) => {
+    const pos = event.target.getStage()?.getPointerPosition()
+    if (pos) {
+      if (shapeType === 'Text') {
+        const { clientX, clientY } = event.evt.touches[0]
+        setAbsPos({
+          x: clientX,
+          y: clientY,
+        })
+      } else if (shapeType === 'Free') {
+        setFreePoints((prev) => [pos.x, pos.y, pos.x, pos.y])
+        return
+      }
+
+      const shape = CreateShape(shapeType, pos, pos)
+      setNewShape(shape)
+      setStart(pos)
+    }
+  }
+
+  const handleMouseMove = (
+    event: Konva.KonvaEventObject<MouseEvent | TouchEvent>
+  ) => {
     const pos = event.target.getStage()?.getPointerPosition()
     if (pos && newShape) {
       if (shapeType === 'Free') {
@@ -211,7 +233,10 @@ export const Canvas = () => {
       setNewShape(shape)
     }
   }
-  const handleMouseUp = (event: Konva.KonvaEventObject<MouseEvent>) => {
+
+  const handleMouseUp = (
+    event: Konva.KonvaEventObject<MouseEvent | TouchEvent>
+  ) => {
     if (shapeType === 'Text') {
       if (absPos && stageRef?.current) {
         edit({
@@ -282,13 +307,17 @@ export const Canvas = () => {
       {(value) => (
         <Stage
           ref={stageRef}
+          preventDefault
           width={1000}
           height={1000}
           onMouseDown={handleMouseDown}
+          onTouchStart={handleTouchStart}
           // Prevent to create a small shape on dragging is started when set Shape type is not "select"
           onDragStart={() => newShape && setNewShape(undefined)}
           onMouseMove={handleMouseMove}
+          onTouchMove={handleMouseMove}
           onMouseUp={handleMouseUp}
+          onTouchEnd={handleMouseUp}
           onClick={handleClick}>
           <TextEditorContext.Provider value={value}>
             <Layer>

--- a/src/features/canvas/components/Canvas.tsx
+++ b/src/features/canvas/components/Canvas.tsx
@@ -16,6 +16,7 @@ import { Vector2d } from 'konva/lib/types'
 import TextBlock from './TextBlock'
 import { TextEditorContext } from 'contexts/TextEditorProvider'
 import { StageRef } from 'contexts/StageRefProvider'
+import { useWindowSize } from '../hooks/useWindowSize'
 
 const CreateShape = (
   shape: string,
@@ -170,6 +171,8 @@ export const Canvas = () => {
   const stageRef = React.useContext(StageRef)
   const transformerRef = React.useRef<Konva.Transformer>(null)
 
+  const windowSize = useWindowSize()
+
   React.useEffect(() => {
     if (pasteData !== undefined) {
       const func = async () => {
@@ -217,6 +220,8 @@ export const Canvas = () => {
       setNewShape(shape)
       setStart(pos)
     }
+
+    event.evt.preventDefault()
   }
 
   const handleMouseMove = (
@@ -232,6 +237,8 @@ export const Canvas = () => {
       const shape = CreateShape(shapeType, start, pos)
       setNewShape(shape)
     }
+
+    event.evt.preventDefault()
   }
 
   const handleMouseUp = (
@@ -255,6 +262,8 @@ export const Canvas = () => {
     }
     setNewShape(undefined)
     setStart({ x: 0, y: 0 })
+
+    event.evt.preventDefault()
   }
 
   React.useEffect(() => {
@@ -308,8 +317,8 @@ export const Canvas = () => {
         <Stage
           ref={stageRef}
           preventDefault
-          width={1000}
-          height={1000}
+          width={windowSize.width}
+          height={windowSize.height}
           onMouseDown={handleMouseDown}
           onTouchStart={handleTouchStart}
           // Prevent to create a small shape on dragging is started when set Shape type is not "select"

--- a/src/features/canvas/hooks/useWindowSize.ts
+++ b/src/features/canvas/hooks/useWindowSize.ts
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react'
+
+const getWindowSize = () => {
+  const { innerWidth: width, innerHeight: height } = window
+  return {
+    width,
+    height,
+  }
+}
+export const useWindowSize = () => {
+  const [windowSize, setWindowSize] = useState(getWindowSize())
+  useEffect(() => {
+    const onResize = () => {
+      setWindowSize(getWindowSize())
+    }
+    window.addEventListener('resize', onResize)
+
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
+
+  return windowSize
+}

--- a/src/pages/Root.tsx
+++ b/src/pages/Root.tsx
@@ -24,7 +24,6 @@ const Root = () => {
         <Navbar />
         <Box
           onCopy={() => console.log('handlePaste')}
-          sx={{ margin: 10, border: 'black' }}
           onPaste={() => console.log('test')}>
           <Canvas />
         </Box>


### PR DESCRIPTION
close #33 

- モバイル上で動くようにイベントリスナーを追加
    - onTouchStart, onTouchMove, onTouchEnd
- 描画中に画面が動かないようにイベントの透過を防止
- キャンバスサイズを画面サイズになるように修正