### PR TITLE
Fix/45 modify mobile display

### DIFF
--- a/src/features/canvas/components/Canvas.tsx
+++ b/src/features/canvas/components/Canvas.tsx
@@ -399,7 +399,10 @@ export const Canvas: React.FC<Props> = ({ width, height }) => {
           </Stage>
         )}
       </TextEditorContext.Consumer>
-      <UploadButton />
+      <UploadButton
+        canvasHeight={canvasSize.height}
+        canvasWidth={canvasSize.width}
+      />
     </div>
   )
 }

--- a/src/features/canvas/components/Canvas.tsx
+++ b/src/features/canvas/components/Canvas.tsx
@@ -17,7 +17,6 @@ import { Vector2d } from 'konva/lib/types'
 import TextBlock from './TextBlock'
 import { TextEditorContext } from 'contexts/TextEditorProvider'
 import { StageRef } from 'contexts/StageRefProvider'
-// import { useWindowSize } from 'features/canvas/hooks/useWindowSize'
 import { useLineConfig } from 'features/config/contexts/LineConfigProvider'
 import { useShapeConfig } from 'features/config/contexts/ShapeConfigProvider'
 import UploadButton from './UploadButton'
@@ -195,7 +194,6 @@ export const Canvas: React.FC<Props> = ({ width, height }) => {
   const [lineConfig] = useLineConfig()
   const [shapeConfig] = useShapeConfig()
 
-  // const windowSize = useWindowSize()
   const canvasSize = useCanvasSize(width, height)
 
   React.useEffect(() => {

--- a/src/features/canvas/components/UploadButton.tsx
+++ b/src/features/canvas/components/UploadButton.tsx
@@ -2,23 +2,22 @@ import * as React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus } from '@fortawesome/free-solid-svg-icons'
 import Fab from '@mui/material/Fab'
-import { useWindowSize } from 'react-use'
 import { useImageLoader } from 'features/canvas/hooks/useImageLoader'
 
 const labelId = 'upload-image-button'
 
-const UploadButton = () => {
-  const windowSize = useWindowSize()
-  const loadImage = useImageLoader(
-    windowSize.width * 0.6,
-    windowSize.height * 0.6
-  )
+type Props = {
+  canvasHeight: number
+  canvasWidth: number
+}
+const UploadButton: React.FC<Props> = ({ canvasHeight, canvasWidth }) => {
+  const loadImage = useImageLoader()
 
   const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files || [])
     if (files.length > 0) {
       files.forEach((file) => {
-        loadImage(file)
+        loadImage(file, canvasHeight, canvasWidth)
       })
     }
   }

--- a/src/features/canvas/hooks/useImageLoader.tsx
+++ b/src/features/canvas/hooks/useImageLoader.tsx
@@ -48,6 +48,8 @@ export const useImageLoader = (width: number, height: number) => {
         <KonvaImage
           draggable
           image={image}
+          // TODO: Window size ではなく Canvas Size の中央に配置するようにする
+          // Window size の変化に対する依存をへらすため
           x={(windowSize.width - maxWidth) / 2}
           y={(windowSize.height - maxHeight) / 2}
           width={size.width}

--- a/src/features/canvas/hooks/useImageLoader.tsx
+++ b/src/features/canvas/hooks/useImageLoader.tsx
@@ -41,10 +41,10 @@ export const useImageLoader = () => {
         <KonvaImage
           draggable
           image={image}
-          // TODO: Window size ではなく Canvas Size の中央に配置するようにする
-          // Window size の変化に対する依存をへらすため
-          x={(width - maxWidth) / 2}
-          y={(height - maxHeight) / 2}
+          // TODO: キャンバスサイズから描画位置を計算しているが、
+          // x, y は Stage 座標に変換する必要がある
+          x={(width - size.width) / 2}
+          y={(height - size.height) / 2}
           width={size.width}
           height={size.height}
         />

--- a/src/features/canvas/hooks/useImageLoader.tsx
+++ b/src/features/canvas/hooks/useImageLoader.tsx
@@ -2,18 +2,9 @@ import * as React from 'react'
 import { Image as KonvaImage } from 'react-konva'
 
 import { useShapes } from '../contexts/ShapesProvider'
-import { useWindowSize } from 'react-use'
 
-export const useImageLoader = (width: number, height: number) => {
-  const [maxWidth, setMaxWidth] = React.useState(width)
-  const [maxHeight, setMaxHeight] = React.useState(height)
+export const useImageLoader = () => {
   const [, actions] = useShapes()
-  const windowSize = useWindowSize()
-
-  React.useEffect(() => {
-    setMaxWidth(width)
-    setMaxHeight(height)
-  }, [width, height])
 
   const handleLoad = React.useCallback(async (src: string) => {
     return await new Promise<HTMLImageElement>((resolve, reject) => {
@@ -28,11 +19,13 @@ export const useImageLoader = (width: number, height: number) => {
   }, [])
 
   const pushImage = React.useCallback(
-    (image: HTMLImageElement) => {
+    (image: HTMLImageElement, height: number, width: number) => {
       const size = {
         width: image.width,
         height: image.height,
       }
+      const maxHeight = height * 0.6
+      const maxWidth = width * 0.6
       // 最大サイズを超えている場合は、はみ出ないサイズに調整
       if (size.width > maxWidth || size.height > maxHeight) {
         if (size.width > size.height) {
@@ -50,22 +43,22 @@ export const useImageLoader = (width: number, height: number) => {
           image={image}
           // TODO: Window size ではなく Canvas Size の中央に配置するようにする
           // Window size の変化に対する依存をへらすため
-          x={(windowSize.width - maxWidth) / 2}
-          y={(windowSize.height - maxHeight) / 2}
+          x={(width - maxWidth) / 2}
+          y={(height - maxHeight) / 2}
           width={size.width}
           height={size.height}
         />
       )
     },
-    [actions, maxHeight, maxWidth, windowSize.height, windowSize.width]
+    [actions]
   )
 
   const loadImage = React.useCallback(
-    async (file: File) => {
+    async (file: File, height: number, width: number) => {
       const url = URL.createObjectURL(file)
       if (url) {
         const image = await handleLoad(url)
-        pushImage(image)
+        pushImage(image, height, width)
       }
       URL.revokeObjectURL(url)
     },

--- a/src/features/config/hooks/useCanvasSize.ts
+++ b/src/features/config/hooks/useCanvasSize.ts
@@ -1,5 +1,7 @@
 import * as React from 'react'
 
+const MARGIN_MAG = 0.9
+
 type CanvasSize = {
   x: number
   y: number
@@ -19,22 +21,25 @@ export const useCanvasSize = (
   })
 
   React.useEffect(() => {
-    const widthHeight = 11 / 21
-    const height = stageHeight * 0.95
-    const width = height * widthHeight * 2
-    const x = (stageWidth - width) / 2
-    const y = (stageHeight - height) / 2
-
-    if (width > stageWidth) {
-      console.log('width is over')
-    } else {
-      setCanvasSize({
-        x,
-        y,
-        width,
-        height,
-      })
+    const widthHeight = 22 / 21
+    const size: CanvasSize = {
+      width: 0,
+      height: 0,
+      x: 0,
+      y: 0,
     }
+
+    // Width / Height の小さい方に合わせてサイズを決める
+    size.width = stageWidth * MARGIN_MAG
+    size.height = size.width / widthHeight
+    if (size.height > stageHeight * MARGIN_MAG) {
+      size.height = stageHeight * MARGIN_MAG
+      size.width = size.height * widthHeight
+    }
+
+    size.x = (stageWidth - size.width) / 2
+    size.y = (stageHeight - size.height) / 2
+    setCanvasSize(size)
   }, [stageHeight, stageWidth])
 
   return canvasSize


### PR DESCRIPTION
close #45 

- 縦長の画面(モバイル)で使うと画面が見切れる問題を修正
  - キャンバスサイズ計算時に、親要素のサイズより大きくならないように計算
- ついでに、画像ローダーがWindow Size に依存していたのを、キャンバスサイズに依存するよう変更